### PR TITLE
Remove unnecessary code for GitHub workflows

### DIFF
--- a/.github/workflows/charts-release-ghpages.yaml
+++ b/.github/workflows/charts-release-ghpages.yaml
@@ -10,11 +10,6 @@ on:
         default: "[]"
         required: false
         type: string
-    secrets:
-      APP_ID:
-        required: true
-      APP_PRIVATE_KEY:
-        required: true
 
 jobs:
   release-charts:


### PR DESCRIPTION
This commit removes the secrets section from the GitHub workflow file, as it is no longer needed.