### PR TITLE
Remove the need for a GitHub App

### DIFF
--- a/.github/workflows/charts-release-ghpages.yaml
+++ b/.github/workflows/charts-release-ghpages.yaml
@@ -16,31 +16,22 @@ jobs:
     name: Release charts
     runs-on: ubuntu-22.04
     steps:
-      - name: Get GitHub API token
-        id: get-app-token
-        uses: getsentry/action-github-app-token@v2
-        with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_PRIVATE_KEY }}
-
       - name: Checkout charts branch
         uses: actions/checkout@v3
         with:
-          token: ${{ steps.get-app-token.outputs.token }}
           path: "src"
           fetch-depth: 0
 
       - name: Checkout gh-pages branch
         uses: actions/checkout@v3
         with:
-          token: ${{ steps.get-app-token.outputs.token }}
           path: "dest"
           ref: "gh-pages"
           fetch-depth: 0
 
       - uses: azure/setup-helm@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }} # only needed if version is 'latest'
+          token: ${{ secrets.GITHUB_TOKEN }}
         id: install
 
       - name: Package Helm Charts


### PR DESCRIPTION
This is only required if someone else starts the workflow
